### PR TITLE
Date/time format incorrectly handles hours

### DIFF
--- a/MySQLDriverMacTests/MySQLDriverMacTests.swift
+++ b/MySQLDriverMacTests/MySQLDriverMacTests.swift
@@ -510,11 +510,11 @@ class MySQLDriverMacTests: XCTestCase {
         do {
             try con.exec("drop table if exists xctest_time")
             try con.exec("create table xctest_time(id INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (id), val TIME)")
-            try con.exec("insert into xctest_time(val) VALUES('12:02:24')")
+            try con.exec("insert into xctest_time(val) VALUES('13:02:24')")
             let res = try con.query("select * from xctest_time")
             let row = try res.readRow()
 
-            if let val = row!["val"] as? NSDate where val == NSDate(timeString: "12:02:24") {
+            if let val = row!["val"] as? NSDate where val == NSDate(timeString: "13:02:24") {
                 XCTAssert(true)
             }
             else {
@@ -530,11 +530,11 @@ class MySQLDriverMacTests: XCTestCase {
         do {
             try con.exec("drop table if exists xctest_datetime")
             try con.exec("create table xctest_datetime(id INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (id), val DATETIME)")
-            try con.exec("insert into xctest_datetime(val) VALUES('2015-12-02 12:02:24')")
+            try con.exec("insert into xctest_datetime(val) VALUES('2015-12-02 13:02:24')")
             let res = try con.query("select * from xctest_datetime")
             let row = try res.readRow()
 
-            if let val = row!["val"] as? NSDate where val == NSDate(dateTimeString: "2015-12-02 12:02:24") {
+            if let val = row!["val"] as? NSDate where val == NSDate(dateTimeString: "2015-12-02 13:02:24") {
                 XCTAssert(true)
             }
             else {
@@ -550,11 +550,11 @@ class MySQLDriverMacTests: XCTestCase {
         do {
             try con.exec("drop table if exists xctest_timestamp")
             try con.exec("create table xctest_timestamp(id INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (id), val TIMESTAMP)")
-            try con.exec("insert into xctest_timestamp(val) VALUES('2015-12-02 12:02:24')")
+            try con.exec("insert into xctest_timestamp(val) VALUES('2015-12-02 13:02:24')")
             let res = try con.query("select * from xctest_timestamp")
             let row = try res.readRow()
 
-            if let val = row!["val"] as? NSDate where val == NSDate(dateTimeString: "2015-12-02 12:02:24") {
+            if let val = row!["val"] as? NSDate where val == NSDate(dateTimeString: "2015-12-02 13:02:24") {
                 XCTAssert(true)
             }
             else {
@@ -874,12 +874,12 @@ class MySQLDriverMacTests: XCTestCase {
         do {
             try con.exec("drop table if exists xctest_stmt_time")
             try con.exec("create table xctest_stmt_time(id INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (id), val TIME)")
-            try con.exec("insert into xctest_stmt_time(val) VALUES('12:02:24')")
+            try con.exec("insert into xctest_stmt_time(val) VALUES('13:02:24')")
             let stmt = try con.prepare("select * from xctest_stmt_time where val=?")
-            let res = try stmt.query(["12:02:24"])
+            let res = try stmt.query(["13:02:24"])
             let row = try res.readRow()
 
-            if let val = row!["val"] as? NSDate where val == NSDate(timeString: "12:02:24") {
+            if let val = row!["val"] as? NSDate where val == NSDate(timeString: "13:02:24") {
                 XCTAssert(true)
             }
             else {
@@ -895,12 +895,12 @@ class MySQLDriverMacTests: XCTestCase {
         do {
             try con.exec("drop table if exists xctest_stmt_datetime")
             try con.exec("create table xctest_stmt_datetime(id INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (id), val DATETIME)")
-            try con.exec("insert into xctest_stmt_datetime(val) VALUES('2015-12-02 12:02:24')")
+            try con.exec("insert into xctest_stmt_datetime(val) VALUES('2015-12-02 13:02:24')")
             let stmt = try con.prepare("select * from xctest_stmt_datetime where val=?")
-            let res = try stmt.query(["2015-12-02 12:02:24"])
+            let res = try stmt.query(["2015-12-02 13:02:24"])
             let row = try res.readRow()
 
-            if let val = row!["val"] as? NSDate where val == NSDate(dateTimeString: "2015-12-02 12:02:24") {
+            if let val = row!["val"] as? NSDate where val == NSDate(dateTimeString: "2015-12-02 13:02:24") {
                 XCTAssert(true)
             }
             else {
@@ -917,12 +917,12 @@ class MySQLDriverMacTests: XCTestCase {
         do {
             try con.exec("drop table if exists xctest_stmt_timestamp")
             try con.exec("create table xctest_stmt_timestamp(id INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (id), val TIMESTAMP)")
-            try con.exec("insert into xctest_stmt_timestamp(val) VALUES('2015-12-02 12:02:24')")
+            try con.exec("insert into xctest_stmt_timestamp(val) VALUES('2015-12-02 13:02:24')")
             let stmt = try con.prepare("select * from xctest_stmt_timestamp where val=?")
-            let res = try stmt.query(["2015-12-02 12:02:24"])
+            let res = try stmt.query(["2015-12-02 13:02:24"])
             let row = try res.readRow()
 
-            if let val = row!["val"] as? NSDate where val == NSDate(dateTimeString: "2015-12-02 12:02:24") {
+            if let val = row!["val"] as? NSDate where val == NSDate(dateTimeString: "2015-12-02 13:02:24") {
                 XCTAssert(true)
             }
             else {

--- a/MySQLDriveriOSTests/MySQLDriveriOSTests.swift
+++ b/MySQLDriveriOSTests/MySQLDriveriOSTests.swift
@@ -509,11 +509,11 @@ class MySQLDriveriOSTests: XCTestCase {
         do {
             try con.exec("drop table if exists xctest_time")
             try con.exec("create table xctest_time(id INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (id), val TIME)")
-            try con.exec("insert into xctest_time(val) VALUES('12:02:24')")
+            try con.exec("insert into xctest_time(val) VALUES('13:02:24')")
             let res = try con.query("select * from xctest_time")
             let row = try res.readRow()
             
-            if let val = row!["val"] as? NSDate where val == NSDate(timeString: "12:02:24") {
+            if let val = row!["val"] as? NSDate where val == NSDate(timeString: "13:02:24") {
                 XCTAssert(true)
             }
             else {
@@ -529,11 +529,11 @@ class MySQLDriveriOSTests: XCTestCase {
         do {
             try con.exec("drop table if exists xctest_datetime")
             try con.exec("create table xctest_datetime(id INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (id), val DATETIME)")
-            try con.exec("insert into xctest_datetime(val) VALUES('2015-12-02 12:02:24')")
+            try con.exec("insert into xctest_datetime(val) VALUES('2015-12-02 13:02:24')")
             let res = try con.query("select * from xctest_datetime")
             let row = try res.readRow()
             
-            if let val = row!["val"] as? NSDate where val == NSDate(dateTimeString: "2015-12-02 12:02:24") {
+            if let val = row!["val"] as? NSDate where val == NSDate(dateTimeString: "2015-12-02 13:02:24") {
                 XCTAssert(true)
             }
             else {
@@ -549,11 +549,11 @@ class MySQLDriveriOSTests: XCTestCase {
         do {
             try con.exec("drop table if exists xctest_timestamp")
             try con.exec("create table xctest_timestamp(id INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (id), val TIMESTAMP)")
-            try con.exec("insert into xctest_timestamp(val) VALUES('2015-12-02 12:02:24')")
+            try con.exec("insert into xctest_timestamp(val) VALUES('2015-12-02 13:02:24')")
             let res = try con.query("select * from xctest_timestamp")
             let row = try res.readRow()
             
-            if let val = row!["val"] as? NSDate where val == NSDate(dateTimeString: "2015-12-02 12:02:24") {
+            if let val = row!["val"] as? NSDate where val == NSDate(dateTimeString: "2015-12-02 13:02:24") {
                 XCTAssert(true)
             }
             else {
@@ -873,12 +873,12 @@ class MySQLDriveriOSTests: XCTestCase {
         do {
             try con.exec("drop table if exists xctest_stmt_time")
             try con.exec("create table xctest_stmt_time(id INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (id), val TIME)")
-            try con.exec("insert into xctest_stmt_time(val) VALUES('12:02:24')")
+            try con.exec("insert into xctest_stmt_time(val) VALUES('13:02:24')")
             let stmt = try con.prepare("select * from xctest_stmt_time where val=?")
-            let res = try stmt.query(["12:02:24"])
+            let res = try stmt.query(["13:02:24"])
             let row = try res.readRow()
             
-            if let val = row!["val"] as? NSDate where val == NSDate(timeString: "12:02:24") {
+            if let val = row!["val"] as? NSDate where val == NSDate(timeString: "13:02:24") {
                 XCTAssert(true)
             }
             else {
@@ -894,12 +894,12 @@ class MySQLDriveriOSTests: XCTestCase {
         do {
             try con.exec("drop table if exists xctest_stmt_datetime")
             try con.exec("create table xctest_stmt_datetime(id INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (id), val DATETIME)")
-            try con.exec("insert into xctest_stmt_datetime(val) VALUES('2015-12-02 12:02:24')")
+            try con.exec("insert into xctest_stmt_datetime(val) VALUES('2015-12-02 13:02:24')")
             let stmt = try con.prepare("select * from xctest_stmt_datetime where val=?")
-            let res = try stmt.query(["2015-12-02 12:02:24"])
+            let res = try stmt.query(["2015-12-02 13:02:24"])
             let row = try res.readRow()
             
-            if let val = row!["val"] as? NSDate where val == NSDate(dateTimeString: "2015-12-02 12:02:24") {
+            if let val = row!["val"] as? NSDate where val == NSDate(dateTimeString: "2015-12-02 13:02:24") {
                 XCTAssert(true)
             }
             else {
@@ -916,12 +916,12 @@ class MySQLDriveriOSTests: XCTestCase {
         do {
             try con.exec("drop table if exists xctest_stmt_timestamp")
             try con.exec("create table xctest_stmt_timestamp(id INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (id), val TIMESTAMP)")
-            try con.exec("insert into xctest_stmt_timestamp(val) VALUES('2015-12-02 12:02:24')")
+            try con.exec("insert into xctest_stmt_timestamp(val) VALUES('2015-12-02 13:02:24')")
             let stmt = try con.prepare("select * from xctest_stmt_timestamp where val=?")
-            let res = try stmt.query(["2015-12-02 12:02:24"])
+            let res = try stmt.query(["2015-12-02 13:02:24"])
             let row = try res.readRow()
             
-            if let val = row!["val"] as? NSDate where val == NSDate(dateTimeString: "2015-12-02 12:02:24") {
+            if let val = row!["val"] as? NSDate where val == NSDate(dateTimeString: "2015-12-02 13:02:24") {
                 XCTAssert(true)
             }
             else {

--- a/Sources/MySqlSwiftNative/Utils.swift
+++ b/Sources/MySqlSwiftNative/Utils.swift
@@ -316,7 +316,7 @@ extension NSDate
     convenience
     init(timeString:String) {
         let dateStringFormatter = NSDateFormatter()
-        dateStringFormatter.dateFormat = "hh-mm-ss"
+        dateStringFormatter.dateFormat = "HH:mm:ss"
         dateStringFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
         let d = dateStringFormatter.dateFromString(timeString)!
         self.init(timeInterval:0, sinceDate:d)
@@ -325,7 +325,7 @@ extension NSDate
     convenience
     init(dateTimeString:String) {
         let dateStringFormatter = NSDateFormatter()
-        dateStringFormatter.dateFormat = "yyyy-MM-dd hh:mm:ss"
+        dateStringFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         dateStringFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
         let d = dateStringFormatter.dateFromString(dateTimeString)!
         self.init(timeInterval:0, sinceDate:d)
@@ -341,14 +341,14 @@ extension NSDate
     
     func timeString() -> String {
         let dateStringFormatter = NSDateFormatter()
-        dateStringFormatter.dateFormat = "hh-mm-ss"
+        dateStringFormatter.dateFormat = "HH:mm:ss"
         dateStringFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
         return dateStringFormatter.stringFromDate(self)
     }
     
     func dateTimeString() -> String {
         let dateStringFormatter = NSDateFormatter()
-        dateStringFormatter.dateFormat = "yyyy-MM-dd hh:mm:ss"
+        dateStringFormatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
         dateStringFormatter.locale = NSLocale(localeIdentifier: "en_US_POSIX")
         return dateStringFormatter.stringFromDate(self)
     }

--- a/Sources/MySqlSwiftNative/tests.swift
+++ b/Sources/MySqlSwiftNative/tests.swift
@@ -634,12 +634,12 @@ class MySQLDriverLinuxTests: XCTestCase {
             open()
             try con.exec("drop table if exists xctest_time")
             try con.exec("create table xctest_time(id INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (id), val TIME)")
-            try con.exec("insert into xctest_time(val) VALUES('12:02:24')")
+            try con.exec("insert into xctest_time(val) VALUES('13:02:24')")
             let res = try con.query("select * from xctest_time")
             let row = try res.readRow()
             try con.close()
             
-            if let val = row!["val"] as? NSDate where val == NSDate(timeString: "12:02:24") {
+            if let val = row!["val"] as? NSDate where val == NSDate(timeString: "13:02:24") {
                 XCTAssert(true)
             }
             else {
@@ -656,12 +656,12 @@ class MySQLDriverLinuxTests: XCTestCase {
             open()
             try con.exec("drop table if exists xctest_datetime")
             try con.exec("create table xctest_datetime(id INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (id), val DATETIME)")
-            try con.exec("insert into xctest_datetime(val) VALUES('2015-12-02 12:02:24')")
+            try con.exec("insert into xctest_datetime(val) VALUES('2015-12-02 13:02:24')")
             let res = try con.query("select * from xctest_datetime")
             let row = try res.readRow()
             try con.close()
             
-            if let val = row!["val"] as? NSDate where val == NSDate(dateTimeString: "2015-12-02 12:02:24") {
+            if let val = row!["val"] as? NSDate where val == NSDate(dateTimeString: "2015-12-02 13:02:24") {
                 XCTAssert(true)
             }
             else {
@@ -678,12 +678,12 @@ class MySQLDriverLinuxTests: XCTestCase {
             open()
             try con.exec("drop table if exists xctest_timestamp")
             try con.exec("create table xctest_timestamp(id INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (id), val TIMESTAMP)")
-            try con.exec("insert into xctest_timestamp(val) VALUES('2015-12-02 12:02:24')")
+            try con.exec("insert into xctest_timestamp(val) VALUES('2015-12-02 13:02:24')")
             let res = try con.query("select * from xctest_timestamp")
             let row = try res.readRow()
             try con.close()
             
-            if let val = row!["val"] as? NSDate where val == NSDate(dateTimeString: "2015-12-02 12:02:24") {
+            if let val = row!["val"] as? NSDate where val == NSDate(dateTimeString: "2015-12-02 13:02:24") {
                 XCTAssert(true)
             }
             else {
@@ -1034,13 +1034,13 @@ class MySQLDriverLinuxTests: XCTestCase {
             open()
             try con.exec("drop table if exists xctest_stmt_time")
             try con.exec("create table xctest_stmt_time(id INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (id), val TIME)")
-            try con.exec("insert into xctest_stmt_time(val) VALUES('12:02:24')")
+            try con.exec("insert into xctest_stmt_time(val) VALUES('13:02:24')")
             let stmt = try con.prepare("select * from xctest_stmt_time where val=?")
-            let res = try stmt.query(["12:02:24"])
+            let res = try stmt.query(["13:02:24"])
             let row = try res.readRow()
             try con.close()
             
-            if let val = row!["val"] as? NSDate where val == NSDate(timeString: "12:02:24") {
+            if let val = row!["val"] as? NSDate where val == NSDate(timeString: "13:02:24") {
                 XCTAssert(true)
             }
             else {
@@ -1057,13 +1057,13 @@ class MySQLDriverLinuxTests: XCTestCase {
             open()
             try con.exec("drop table if exists xctest_stmt_datetime")
             try con.exec("create table xctest_stmt_datetime(id INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (id), val DATETIME)")
-            try con.exec("insert into xctest_stmt_datetime(val) VALUES('2015-12-02 12:02:24')")
+            try con.exec("insert into xctest_stmt_datetime(val) VALUES('2015-12-02 13:02:24')")
             let stmt = try con.prepare("select * from xctest_stmt_datetime where val=?")
-            let res = try stmt.query(["2015-12-02 12:02:24"])
+            let res = try stmt.query(["2015-12-02 13:02:24"])
             let row = try res.readRow()
             try con.close()
             
-            if let val = row!["val"] as? NSDate where val == NSDate(dateTimeString: "2015-12-02 12:02:24") {
+            if let val = row!["val"] as? NSDate where val == NSDate(dateTimeString: "2015-12-02 13:02:24") {
                 XCTAssert(true)
             }
             else {
@@ -1081,13 +1081,13 @@ class MySQLDriverLinuxTests: XCTestCase {
             open()
             try con.exec("drop table if exists xctest_stmt_timestamp")
             try con.exec("create table xctest_stmt_timestamp(id INT NOT NULL AUTO_INCREMENT, PRIMARY KEY (id), val TIMESTAMP)")
-            try con.exec("insert into xctest_stmt_timestamp(val) VALUES('2015-12-02 12:02:24')")
+            try con.exec("insert into xctest_stmt_timestamp(val) VALUES('2015-12-02 13:02:24')")
             let stmt = try con.prepare("select * from xctest_stmt_timestamp where val=?")
-            let res = try stmt.query(["2015-12-02 12:02:24"])
+            let res = try stmt.query(["2015-12-02 13:02:24"])
             let row = try res.readRow()
             try con.close()
             
-            if let val = row!["val"] as? NSDate where val == NSDate(dateTimeString: "2015-12-02 12:02:24") {
+            if let val = row!["val"] as? NSDate where val == NSDate(dateTimeString: "2015-12-02 13:02:24") {
                 XCTAssert(true)
             }
             else {


### PR DESCRIPTION
Loading a date or time that is in the afternoon causes a crash with a force unwrapped optional. The date & time formatters are using `hh` for hours, which formats hours 01-12. MySQL uses 24-hour time (formatted 00-23).

I updated the formatters in Utils.swift to use the correct hour format, and did a simple find & replace across the test suite to change the test time `12:02:24` to `13:02:24` to test the issue.

Cheers!